### PR TITLE
Add namespace to Android build.gradle

### DIFF
--- a/packages/proxy_setting_android/android/build.gradle
+++ b/packages/proxy_setting_android/android/build.gradle
@@ -40,6 +40,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "jp.playon.proxy_setting_android"
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
The new version of AGP requires namespace configuration for compilation to succeed.